### PR TITLE
Fixes swapping objects.

### DIFF
--- a/src/json-patch-duplex.js
+++ b/src/json-patch-duplex.js
@@ -380,7 +380,7 @@ var jsonpatch;
             var oldVal = mirror[key];
             if (obj.hasOwnProperty(key)) {
                 var newVal = obj[key];
-                if (oldVal instanceof Object) {
+                if (oldVal instanceof Object && newVal instanceof Object) {
                     _generate(oldVal, newVal, patches, path + "/" + escapePathComponent(key));
                 } else {
                     if (oldVal != newVal) {


### PR DESCRIPTION
This resolves #30.

It needs tests, but I figured I'd open the PR to get the discussion going.

To test,

```js
// On master, you'll get an error
var patch = jsonpatch.compare({a: {}}, {a: null});

// On my branch, you get a diff:
patch === {
  op: "replace"
  path: "/a"
  value: true
};
```